### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-gateway-rs.yml
+++ b/.github/workflows/main-gateway-rs.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/main-gateway-rs.yml'
       - 'cargo.toml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/mingchiuli/megalith-micro/security/code-scanning/29](https://github.com/mingchiuli/megalith-micro/security/code-scanning/29)

To fix the problem, add a `permissions` block at the top of the workflow, below the `name` and `on` definitions, to explicitly specify the minimum required permissions. All jobs in the workflow only need `contents: read` at most, since there are no steps which need the `GITHUB_TOKEN` for writing to the repository or interacting with PRs/issues. This change adheres to the principle of least privilege, reduces potential attack surface, and satisfies CodeQL.

Specifically, edit `.github/workflows/main-gateway-rs.yml` to add:

```yaml
permissions:
  contents: read
```

after the workflow name and trigger (`on:` block), and before the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
